### PR TITLE
Add discogs support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ pip install -U pyacoustid && \
 pip install -U pylast && \
 pip install -U flask && \
 pip install -U pillow && \
+pip install -U discogs && \
 pip install -U beets && \
 apt-get clean && rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/*
 

--- a/defaults/config.yaml
+++ b/defaults/config.yaml
@@ -1,4 +1,4 @@
-plugins: fetchart embedart convert scrub replaygain lastgenre chroma web
+plugins: fetchart embedart convert scrub replaygain lastgenre chroma web discogs
 directory: /music
 library: /config/musiclibrary.blb
 art_filename: albumart


### PR DESCRIPTION
While Musicbrainz has a vast majority of the metadata one needs, discogs is a good backup and should be available for use.  It can technically still be disabled via the config, so if anything we can remove it from there.

Adding discogs when the container starts remove the need for one to have to bash in and install it every time they start beets.