### PR TITLE
Add support for the copyartifacts plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -76,6 +76,7 @@ RUN \
 	pillow \
 	pip \
 	pyacoustid \
+	beets-copyartifacts \	
 	pylast && \
 
 # cleanup


### PR DESCRIPTION
The `copyartifacts` plugin `helps bring non-music files along during import.`

https://github.com/sbarakat/beets-copyartifacts

