### PR TITLE
Include Discogs Plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,7 @@ RUN \
 	beautifulsoup4 \
 	beets \
 	beets-copyartifacts \
+	discogs-client \
 	flask \
 	pillow \
 	pip \


### PR DESCRIPTION
I've been using this plugin for a while and it really helps broaden beets ability to find matches for new albums. 
Information available here https://beets.readthedocs.io/en/latest/plugins/discogs.html

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

