### PR TITLE
Add gmusicapi pip package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN \
 	make \
 	mpg123-dev \
 	openjpeg-dev \
+	libxml2-dev \
+	libxslt-dev \
 	python2-dev && \
  echo "**** install runtime packages ****" && \
  apk add --no-cache \
@@ -69,6 +71,7 @@ RUN \
 	beets \
 	beets-copyartifacts \
 	discogs-client \
+	gmusicapi \
 	flask \
 	pillow \
 	pip \


### PR DESCRIPTION
Adding `gmusicapi` pip package allows for the [Gmusic plugin](https://beets.readthedocs.io/en/v1.4.7/plugins/gmusic.html) to be used.