### PR TITLE
rebasing to alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG ALPINE_VER="3.9"
+ARG ALPINE_VER="3.10"
 FROM lsiobase/alpine:${ALPINE_VER} as fetch-stage
 
 ############## fetch stage ##############

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,7 +160,7 @@ FROM lsiobase/alpine:${ALPINE_VER} as strip-stage
 COPY --from=beets_build-stage /build/beets/usr/ /build/all//usr/
 COPY --from=chromaprint_build-stage /build/chromaprint/usr/ /build/all//usr/
 COPY --from=mp3gain_build-stage /build/mp3gain/usr/ /build/all//usr/
-COPY --from=pip-stage /usr/lib/python3.6/site-packages /build/all/usr/lib/python3.6/site-packages
+COPY --from=pip-stage /usr/lib/python3.7/site-packages /build/all/usr/lib/python3.7/site-packages
 
 # install strip packages
 RUN \
@@ -174,7 +174,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # strip packages
 RUN \
 	set -ex && \
- for dirs in usr/bin usr/lib usr/lib/python3.6/site-packages; \
+ for dirs in usr/bin usr/lib usr/lib/python3.7/site-packages; \
 	do \
 		find /build/all/"${dirs}" -type f | \
 		while read -r files ; do strip "${files}" || true \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -164,7 +164,7 @@ FROM lsiobase/alpine:arm64v8-${ALPINE_VER} as strip-stage
 COPY --from=beets_build-stage /build/beets/usr/ /build/all//usr/
 COPY --from=chromaprint_build-stage /build/chromaprint/usr/ /build/all//usr/
 COPY --from=mp3gain_build-stage /build/mp3gain/usr/ /build/all//usr/
-COPY --from=pip-stage /usr/lib/python3.6/site-packages /build/all/usr/lib/python3.6/site-packages
+COPY --from=pip-stage /usr/lib/python3.7/site-packages /build/all/usr/lib/python3.7/site-packages
 
 # install strip packages
 RUN \
@@ -178,7 +178,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # strip packages
 RUN \
 	set -ex && \
- for dirs in usr/bin usr/lib usr/lib/python3.6/site-packages; \
+ for dirs in usr/bin usr/lib usr/lib/python3.7/site-packages; \
 	do \
 		find /build/all/"${dirs}" -type f | \
 		while read -r files ; do strip "${files}" || true \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -1,4 +1,4 @@
-ARG ALPINE_VER="3.9"
+ARG ALPINE_VER="3.10"
 FROM lsiobase/alpine:arm64v8-${ALPINE_VER} as fetch-stage
 
 ############## fetch stage ##############

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -160,7 +160,7 @@ FROM lsiobase/alpine:arm32v7-${ALPINE_VER} as strip-stage
 COPY --from=beets_build-stage /build/beets/usr/ /build/all//usr/
 COPY --from=chromaprint_build-stage /build/chromaprint/usr/ /build/all//usr/
 COPY --from=mp3gain_build-stage /build/mp3gain/usr/ /build/all//usr/
-COPY --from=pip-stage /usr/lib/python3.6/site-packages /build/all/usr/lib/python3.6/site-packages
+COPY --from=pip-stage /usr/lib/python3.7/site-packages /build/all/usr/lib/python3.7/site-packages
 
 # install strip packages
 RUN \
@@ -174,7 +174,7 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 # strip packages
 RUN \
 	set -ex && \
- for dirs in usr/bin usr/lib usr/lib/python3.6/site-packages; \
+ for dirs in usr/bin usr/lib usr/lib/python3.7/site-packages; \
 	do \
 		find /build/all/"${dirs}" -type f | \
 		while read -r files ; do strip "${files}" || true \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -1,4 +1,4 @@
-ARG ALPINE_VER="3.9"
+ARG ALPINE_VER="3.10"
 FROM lsiobase/alpine:arm32v7-${ALPINE_VER} as fetch-stage
 
 ############## fetch stage ##############

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -33,6 +33,7 @@ param_ports:
 
 # changelog
 changelogs:
+  - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "23.03.19:", desc: "Switching to new Base images, shift to arm32v7 tag." }
   - { date: "01.03.19:", desc: "Switch to python3." }
   - { date: "07.02.19:", desc: "Add fftw-dev build dependency for chromaprint." }


### PR DESCRIPTION
This is part of a mass upgrade to 3.10. 

Basic smoke test should be performed before merging and notes should be tracked in the internal 3.10 Spreadsheet.