### PR TITLE
add requests_oauthlib for beatport plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -94,6 +94,7 @@ RUN \
 	pip \
 	pyacoustid \
 	requests \
+	requests_oauthlib \
 	unidecode && \
  echo "**** cleanup ****" && \
  apk del --purge \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -94,6 +94,7 @@ RUN \
 	pip \
 	pyacoustid \
 	requests \
+	requests_oauthlib \
 	unidecode && \
  echo "**** cleanup ****" && \
  apk del --purge \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -94,6 +94,7 @@ RUN \
 	pip \
 	pyacoustid \
 	requests \
+	requests_oauthlib \
 	unidecode && \
  echo "**** cleanup ****" && \
  apk del --purge \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -39,6 +39,7 @@ param_ports:
 
 # changelog
 changelogs:
+  - { date: "27.10.20:", desc: "Add requests_oauthlib pip package for beatport plugin." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }
   - { date: "28.06.19:", desc: "Rebasing to alpine 3.10." }
   - { date: "12.05.19:", desc: "Add flac and mp3val binaries required for badfiles plugin." }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


 - [x] I have read the [contributing](https://github.com/linuxserver/docker-beets/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
closes #73 

## Benefits of this PR and context:
Makes the beatport plugin able to query the beatport API.

Error message when the requests_oauthlib package isn't installed and the beatport plugin enabled:

```
** error loading plugin beatport:
Traceback (most recent call last):
File "/usr/lib/python3.8/site-packages/beets/plugins.py", line 273, in load_plugins
namespace = __import__(modname, None, None)
File "/usr/lib/python3.8/site-packages/beetsplug/beatport.py", line 25, in <module>
from requests_oauthlib import OAuth1Session
ModuleNotFoundError: No module named 'requests_oauthlib'
```