### PR TITLE
Fix readme app setup info

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ For a command prompt as user abc `docker exec -it -u abc beets bash`
 
 See [Beets](http://beets.io/) for more info.
 
-Contains [beets-copyartifacts](https://github.com/sbarakat/beets-copyartifacts) plugin, [configuration details](https://github.com/sbarakat/beets-copyartifacts#configuration)
+Contains [beets-extrafiles](https://github.com/Holzhaus/beets-extrafiles) plugin, [configuration details](https://github.com/Holzhaus/beets-extrafiles#usage)
 
 ## Usage
 

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -48,7 +48,7 @@ app_setup_block: |
 
   See [Beets](http://beets.io/) for more info.
 
-  Contains [beets-copyartifacts](https://github.com/sbarakat/beets-copyartifacts) plugin, [configuration details](https://github.com/sbarakat/beets-copyartifacts#configuration)
+  Contains [beets-extrafiles](https://github.com/Holzhaus/beets-extrafiles) plugin, [configuration details](https://github.com/Holzhaus/beets-extrafiles#usage)
 
 # changelog
 changelogs:


### PR DESCRIPTION
Related to #79, the readme app setup info should refer to `beets-extrafiles` and not `beets-copyartifacts` since it was swapped in #47.