### PR TITLE
fix: Addded flask-cors for web plugin to use

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -82,6 +82,7 @@ RUN \
     beetcamp \
     python3-discogs-client \
     flask \
+    flask-cors \
     PyGObject \
     pyacoustid \
     pylast \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -83,6 +83,7 @@ RUN \
     beetcamp \
     python3-discogs-client \
     flask \
+    flask-cors \
     PyGObject \
     pyacoustid \
     pylast \

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -81,6 +81,7 @@ init_diagram: |
   "beets:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "09.04.25:", desc: "Add flask-cors required for [web plugin](https://beets.readthedocs.io/en/stable/plugins/web.html)."}
   - {date: "27.01.25:", desc: "Rebase to Alpine 3.21."}
   - {date: "01.10.24:", desc: "Add packages required for Discogs plugin."}
   - {date: "28.08.24:", desc: "Rebase to Alpine 3.20, switch from Pillow to Imagemagick."}


### PR DESCRIPTION
[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-beets/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:
Add `flask-cors` python package to the image.

## Benefits of this PR and context:
This PR adds to the python packages available to the app. The  web plugin uses `flask-cors`

## How Has This Been Tested?
1. Bulit a new docker image
2. Run it and changed the config and added cors support to the web plugin.
3. Used an external beet web frontend (beetle)  to play a track.
4. No changes to any code

## Source / References:
[web plugin documentation](https://beets.readthedocs.io/en/stable/plugins/web.html)
