### PR TITLE
drop2beets implementation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -88,7 +88,8 @@ RUN \
     requests \
     requests_oauthlib \
     typing-extensions \
-    unidecode && \
+    unidecode \
+    drop2beets && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apk del --purge \
@@ -102,6 +103,8 @@ RUN \
 ENV BEETSDIR="/config" \
 EDITOR="nano" \
 HOME="/config"
+
+RUN mkdir /downloads #it freaked out without this :(
 
 # copy local files
 COPY root/ /

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -89,7 +89,8 @@ RUN \
     requests \
     requests_oauthlib \
     typing-extensions \
-    unidecode && \
+    unidecode \
+    drop2beets && \
   printf "Linuxserver.io version: ${VERSION}\nBuild-date: ${BUILD_DATE}" > /build_version && \
   echo "**** cleanup ****" && \
   apk del --purge \
@@ -103,6 +104,8 @@ RUN \
 ENV BEETSDIR="/config" \
 EDITOR="nano" \
 HOME="/config"
+
+RUN mkdir /downloads #it doesn't start without this :/
 
 # copy local files
 COPY root/ /

--- a/root/defaults/config.yaml
+++ b/root/defaults/config.yaml
@@ -1,4 +1,6 @@
-plugins: fetchart embedart convert scrub replaygain lastgenre chroma web
+plugins: fetchart embedart convert scrub replaygain lastgenre chroma web drop2beets
+drop2beets:
+    dropbox_path: /downloads
 directory: /music
 library: /config/musiclibrary.blb
 art_filename: albumart
@@ -21,8 +23,8 @@ paths:
         
 import:
     write: yes
-    copy: yes
-    move: no
+    copy: no
+    move: yes
     resume: ask
     incremental: yes
     quiet_fallback: skip

--- a/root/etc/s6-overlay/s6-rc.d/svc-beets/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-beets/run
@@ -1,6 +1,11 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
+if [[ -v DROP_ENABLED ]]; then
+    echo "dropbox is enabled"
+    beet dropbox &
+fi
+
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     exec \
         s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 8337" \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Drop2beets requires more dependencies than can be included by just dropping in the plugin file. It also seems pretty usefull as it allows the container to run more as a daemon (moving all incoming files under /downloads). 

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-beets/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
[Drop2beets](https://github.com/martinkirch/drop2beets/tree/master) is a plugin that allows beet to scan a folder and automatically move any files that come into it to the library. It's got some requirements (i think the package is called watchdog) that doesn't come normally on the container.

 I've fixed this on my local version fine (execing into the container and running a pip install), but it would maybe be beneficial to include this plugin in the main container since i believe it is in the "spirit" of containers/services (not the strongest argument but well. it's all i got :) )
 
 I did my best to implement it as best as i can without any major changes. added 1 extra package to the pip install at the start, also added an extra run command to make /downloads exist at runtime (since that is what i've set drop2beet to scan for by default)
 
 I've modified the startup script to only run the plugin if the env var DROP_ENABLED is set (any value).
 
 Unfortunately i did have to rewrite the config file a bit. Drop2beet works best with move enabled as opposed to copy so i did change that. I didn't want to assume what way the project would prefer to "template"/edit these config files on launch depending on the parameters, but i'm willing to implement it so it works just like it did before my changes.
 
 Also this is the first time i've ever made a pull request. I'm doing my best o7

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

It does not fix a bug, however it does allow users another capability of running the container as a service by itself, automatically letting it import tracks that are placed under /downloads into it's library which i personally deem as beneficial and assume others will aswell.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

I build the dockerfile using podman, using some trial and error testing with modifying the startup script under ``` root/etc/s6-overlay/s6-rc.d/svc-beets/run``` until i got the plugin to start up only when giving the env var and having it not halt any other parts of the script (web service still starts up)

I admit, i don't really understand what ``` s6-notifyoncheck``` does, but adding it stopped the rest of the stuff from proceeding. so i just used a ```&``` sign to start the plugin in the background


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

the link to the drop2beets project: https://github.com/martinkirch/drop2beets/tree/master
